### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/in_elb_log.rb
+++ b/lib/fluent/plugin/in_elb_log.rb
@@ -9,8 +9,8 @@ class Fluent::Elb_LogInput < Fluent::Input
     define_method("router") { Fluent::Engine }
   end
 
-  config_param :access_key_id, :string, :default => nil
-  config_param :secret_access_key, :string, :default => nil
+  config_param :access_key_id, :string, :default => nil, :secret => true
+  config_param :secret_access_key, :string, :default => nil, :secret => true
   config_param :region, :string, :default => nil
   config_param :s3_bucketname, :string, :default => nil
   config_param :s3_prefix, :string, :default => nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

```log
  <source>
    type elb_log
    region us-east-1
    s3_bucketname my-elblog-bucket
    s3_prefix prodcution/web
    timestamp_file /tmp/elb_last_at.dat
    buf_file /tmp/fluentd-elblog.tmpfile
    refresh_interval 300
    tag elb.access
    access_key_id xxxxxx
    secret_access_key xxxxxx
  </source>
  <match elb.access>
    type stdout
  </match>
</ROOT>
```

If you use older fluentd, `:secret => true` in config_param will be simply ignored.