### PR TITLE
Add a missing require

### DIFF
--- a/lib/fluent/plugin/in_elb_log.rb
+++ b/lib/fluent/plugin/in_elb_log.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::Elb_LogInput < Fluent::Input
   Fluent::Plugin.register_input('elb_log', self)
 


### PR DESCRIPTION
Nowadays, Fluentd requires `'fluent/input'` require directive in Input plugin.