### PR TITLE
Fix #27

### DIFF
--- a/test/plugin/in_elb_log.rb
+++ b/test/plugin/in_elb_log.rb
@@ -51,12 +51,14 @@ class Elb_LogInputTest < Test::Unit::TestCase
   end
 
   def s3bucket_ok
-    stub_request(:get, 'https://s3-ap-northeast-1.amazonaws.com/dummy_bucket?encoding-type=url&max-keys=1&prefix=test')
+    stub_request(:get, 'https://s3.ap-northeast-1.amazonaws.com/dummy_bucket?encoding-type=url&max-keys=1&prefix=test')
+     .with(:headers => {:user_agent => 'aws-sdk-ruby2/2.10.82 ruby/2.4.2 x86_64-darwin17'})
       .to_return(status: 200, body: "", headers: {})
   end
 
   def s3bucket_not_found
-    stub_request(:get, 'https://s3-ap-northeast-1.amazonaws.com/dummy_bucket?encoding-type=url&max-keys=1&prefix=test')
+    stub_request(:get, 'https://s3.ap-northeast-1.amazonaws.com/dummy_bucket?encoding-type=url&max-keys=1&prefix=test')
+      .with(:headers => {:user_agent => 'aws-sdk-ruby2/2.10.82 ruby/2.4.2 x86_64-darwin17'})
       .to_return(status: 404, body: "", headers: {})
   end
 


### PR DESCRIPTION
Without using `continuation_token`, you can only get 1000 objects at maximum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shinsaka/fluent-plugin-elb-log/28)
<!-- Reviewable:end -->
