### PR TITLE
Delete processed log files from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt (If you using amazon linux)
   buf_file          <buffer file path>
   refresh_interval  <interval number by second>
   tag               <tag name(default: elb.access)>
+  delete            <boolean delete processed log files from S3(default: false)>
 
   # following attibutes are required if you don't use IAM Role
   access_key_id     <access_key>
@@ -74,6 +75,7 @@ SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt (If you using amazon linux)
   buf_file          /tmp/fluentd-elblog.tmpfile
   refresh_interval  300
   tag               elb.access
+  delete            false
   access_key_id     XXXXXXXXXXXXXXXXXXXX
   secret_access_key xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 </source>


### PR DESCRIPTION
This change introduces a new configuration parameter `delete` (`false` by default), which, when set to `true` will delete processed log files from S3 bucket.

This comes in handy in cases where one does not want to reprocess all the LB log files stored in S3 in case timestamp file is lost, which as I see it can easily be lost when the instance that runs fluentd is terminated.

closes #32 