### PR TITLE
Using this plugin I found the trace-id was getting pulled into the ta…

### DIFF
--- a/lib/fluent/plugin/in_elb_log.rb
+++ b/lib/fluent/plugin/in_elb_log.rb
@@ -11,7 +11,7 @@ class Fluent::Plugin::Elb_LogInput < Fluent::Plugin::Input
   helpers :timer
 
   LOGFILE_REGEXP = /^((?<prefix>.+?)\/|)AWSLogs\/(?<account_id>[0-9]{12})\/elasticloadbalancing\/(?<region>.+?)\/(?<logfile_date>[0-9]{4}\/[0-9]{2}\/[0-9]{2})\/[0-9]{12}_elasticloadbalancing_.+?_(?<logfile_elb_name>[^_]+)_(?<elb_timestamp>[0-9]{8}T[0-9]{4}Z)_(?<elb_ip_address>.+?)_(?<logfile_hash>.+)\.log(.gz)?$/
-  ACCESSLOG_REGEXP = /^((?<type>[a-z0-9]+) )?(?<time>\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (?<elb>.+?) (?<client>[^ ]+)\:(?<client_port>.+?) (?<backend>.+?)(\:(?<backend_port>.+?))? (?<request_processing_time>.+?) (?<backend_processing_time>.+?) (?<response_processing_time>.+?) (?<elb_status_code>.+?) (?<backend_status_code>.+?) (?<received_bytes>.+?) (?<sent_bytes>.+?) \"(?<request_method>.+?) (?<request_uri>.+?) (?<request_protocol>.+?)\"( \"(?<user_agent>.*?)\" (?<ssl_cipher>.+?) (?<ssl_protocol>[^\s]+)( (?<target_group_arn>arn:.+) (?<trace_id>[^\s]+))?(| (?<option3>.*)))?/
+  ACCESSLOG_REGEXP = /^((?<type>[a-z0-9]+) )?(?<time>\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (?<elb>.+?) (?<client>[^ ]+)\:(?<client_port>.+?) (?<backend>.+?)(\:(?<backend_port>.+?))? (?<request_processing_time>.+?) (?<backend_processing_time>.+?) (?<response_processing_time>.+?) (?<elb_status_code>.+?) (?<backend_status_code>.+?) (?<received_bytes>.+?) (?<sent_bytes>.+?) \"(?<request_method>.+?) (?<request_uri>.+?) (?<request_protocol>.+?)\"( \"(?<user_agent>.*?)\" (?<ssl_cipher>.+?) (?<ssl_protocol>[^\s]+)( (?<target_group_arn>arn:\S+) (?<trace_id>[^\s]+))?(| (?<option3>.*)))?/
 
   config_param :access_key_id, :string, default: nil, secret: true
   config_param :secret_access_key, :string, default: nil, secret: true


### PR DESCRIPTION
…rget-group arn field. I corrected the regex to stop the match at the first whitespace and tested the new reqex using: http://rubular.com/ and the following log line `http 2018-03-15T03:50:00.337397Z app/svc-hg-production-east-blue-2/dcf5479ed8d03bc6 10.248.9.92:54000 10.248.9.77:80 0.000 0.052 0.000 200 200 686 6476 "GET http://services-lb.nottherealsite.net:80/svc/v3_4/providersearch/ProviderProfile/772AZ?s.what=Speech-Language+Pathology&s.where=Forest+Park%2c+IL+60130&s.pt=41.864907%2c-87.804277&s.SearchType=PracticingSpecialty&s.EntityCode=PS1023&cw.FacetLazyLoad=true&cw.Facet=false&s.PracticingSpecialtyCodes=%22PS1023%22&experienceScore=true&compareWidget=True HTTP/1.1" "-" - - arn:aws:elasticloadbalancing:us-east-1:123456789123:targetgroup/prod-svc-b-0-i/39a872227ad8676a "Root=1-5aa9ed68-609415c9be383a14005cd7d1" "-" "-" 3`


The change (?<target_group_arn>arn:.+) to (?<target_group_arn>arn:\S+)