### PR TITLE
Emit the time of the ELB access rather than the time that this plugin ran

### DIFF
--- a/lib/fluent/plugin/in_elb_log.rb
+++ b/lib/fluent/plugin/in_elb_log.rb
@@ -286,7 +286,7 @@ class Fluent::Plugin::Elb_LogInput < Fluent::Plugin::Input
             next
           end
 
-          router.emit(@tag, Fluent::Engine.now, record_common.merge(format_record(line_match)))
+          router.emit(@tag, Time.parse(line_match[:time]), record_common.merge(format_record(line_match)))
         end
       end
     rescue => e


### PR DESCRIPTION
I noticed that the time of the event in td-agent is actually the time the plugin ran, which is used by other output plugins & therefore causes the wrong timestamp to be associated with entries. This commit ensures that the plugin emits the time of the ELB request for each entry.