### PR TITLE
Fix time must be a Fluent::EventTime (or Integer)

### DIFF
--- a/lib/fluent/plugin/in_elb_log.rb
+++ b/lib/fluent/plugin/in_elb_log.rb
@@ -70,8 +70,8 @@ class Fluent::Plugin::Elb_LogInput < Fluent::Plugin::Input
       log.debug "timestamp file #{@timestamp_file} read"
       File.open(@timestamp_file, File::RDONLY) do |file|
         if file.size > 0
-          timestamp_from_file = file.read.to_i 
-          if timestamp_from_file > timestamp 
+          timestamp_from_file = file.read.to_i
+          if timestamp_from_file > timestamp
             timestamp = timestamp_from_file
           end
         end
@@ -196,7 +196,7 @@ class Fluent::Plugin::Elb_LogInput < Fluent::Plugin::Input
 
         object_key = content.key
         node_no = Digest::SHA1.hexdigest(object_key).to_i(16) % @num_nodes
-        next unless node_no == @node_no 
+        next unless node_no == @node_no
 
         matches = LOGFILE_REGEXP.match(object_key)
         if s3_last_modified_unixtime > timestamp and matches
@@ -286,7 +286,10 @@ class Fluent::Plugin::Elb_LogInput < Fluent::Plugin::Input
             next
           end
 
-          router.emit(@tag, Time.parse(line_match[:time]), record_common.merge(format_record(line_match)))
+          now = Fluent::Engine.now
+          time = Time.parse(line_match[:time]).to_i rescue now
+
+          router.emit(@tag, time, record_common.merge(format_record(line_match)))
         end
       end
     rescue => e


### PR DESCRIPTION
This should fix error introduced by #36 :

```
emit transaction failed: error_class=ArgumentError error=\"time must be a Fluent::EventTime (or Integer): Time

/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/output.rb:796:in `metadata'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/output.rb:951:in `block in handle_stream_with_standard_format'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event.rb:193:in `block in each'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event.rb:192:in `each'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event.rb:192:in `each'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/output.rb:950:in `handle_stream_with_standard_format'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/output.rb:860:in `execute_chunking'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/output.rb:779:in `emit_buffered'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/out_copy.rb:58:in `block in process'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/out_copy.rb:56:in `each'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/out_copy.rb:56:in `each_with_index'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/out_copy.rb:56:in `process'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin/multi_output.rb:148:in `emit_sync'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event_router.rb:159:in `emit_events'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event_router.rb:96:in `emit_stream'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/event_router.rb:87:in `emit'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:289:in `block (2 levels) in emit_lines_from_buffer_file'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:282:in `each_line'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:282:in `block in emit_lines_from_buffer_file'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:281:in `open'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:281:in `emit_lines_from_buffer_file'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:154:in `block in input'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:138:in `each'
/usr/lib/ruby/gems/2.4.0/gems/fluent-plugin-elb-log-0.9.0/lib/fluent/plugin/in_elb_log.rb:138:in `input'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin_helper/timer.rb:80:in `on_timer'
/usr/lib/ruby/gems/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run_once'
/usr/lib/ruby/gems/2.4.0/gems/cool.io-1.5.3/lib/cool.io/loop.rb:88:in `run'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin_helper/event_loop.rb:93:in `block in start'
/usr/lib/ruby/gems/2.4.0/gems/fluentd-1.2.6/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```